### PR TITLE
Translates original errors array from "ajv-errors"

### DIFF
--- a/localize/localize.jst
+++ b/localize/localize.jst
@@ -7,7 +7,7 @@
 }}
 
 {{ var name = 'localize_' + it.locale.replace('-','_'); }}
-module.exports = function {{=name}}(errors) {
+var {{=name}} = function {{=name}}(errors) {
   if (!(errors && errors.length)) return;
   for (var i=0; i<errors.length; i++) {
     var e = errors[i];
@@ -18,11 +18,15 @@ module.exports = function {{=name}}(errors) {
           {{= stripFunction(msg.msgFunc) }}
           break;
       {{~}}
+      case 'errorMessage':
+        {{=name}}(e.params.errors);
+        continue;
       default: continue;
     }
     e.message = out;
   }
 };
+module.exports = {{=name}};
 
 {{
   function stripFunction(code) {


### PR DESCRIPTION
Translates the original ajv errors array that "ajv-errors" module puts inside "params".