### PR TITLE
Set "custom" translated message as default.

### DIFF
--- a/localize/localize.jst
+++ b/localize/localize.jst
@@ -14,6 +14,7 @@ var {{=name}} = function {{=name}}(errors) {
     var out;
     switch (e.keyword) {
       {{~ it.messages:msg }}
+        {{ if(msg.keyword == 'custom') var custom = msg; }}
         case '{{= msg.keyword }}':
           {{= stripFunction(msg.msgFunc) }}
           break;
@@ -21,7 +22,8 @@ var {{=name}} = function {{=name}}(errors) {
       case 'errorMessage':
         {{=name}}(e.params.errors);
         continue;
-      default: continue;
+      default:
+        {{= stripFunction(custom.msgFunc) }}
     }
     e.message = out;
   }


### PR DESCRIPTION
Sets the "custom" translated message as default, useful for custom defined keywords.